### PR TITLE
Downgrade gRPC version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/pion/webrtc/v2 v2.2.23
 	github.com/rs/zerolog v1.19.0
 	github.com/spf13/viper v1.7.1
-	google.golang.org/grpc v1.31.0
+	google.golang.org/grpc v1.26.0
 )


### PR DESCRIPTION
It seems that etcd <3.5 has an issue with gRPC >1.26. So while `ion-avp` builds no problem, using `v1.31` will cause problems when `ion-avp` is built with `ion`. See these issues for more details:

https://github.com/etcd-io/etcd/issues/11154
https://github.com/etcd-io/etcd/issues/11931

In theory this is also fixed with etcd v3.5, but it has yet to be released.

There also might be a better solution here, but I tried pinning versions and go really doesn't seem to like that, it keeps overriding gRPC to v1.31 and the etcd build fails.