### PR TITLE
Revert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/pion/webrtc/v3 v3.0.0-beta.4.0.20200908143909-40eb1f2404c0
 	github.com/rs/zerolog v1.19.0
 	github.com/spf13/viper v1.7.1
-	google.golang.org/grpc v1.32.0
+	google.golang.org/grpc v1.27.1
 	google.golang.org/protobuf v1.23.0
 )

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,7 @@ github.com/pion/udp v0.1.0 h1:uGxQsNyrqG3GLINv36Ff60covYmfrLoxzwnCsIYspXI=
 github.com/pion/udp v0.1.0/go.mod h1:BPELIjbwE9PRbd/zxI/KYBnbo7B6+oA6YuEaNE8lths=
 github.com/pion/webrtc/v3 v3.0.0-beta.4.0.20200902134452-789ff0975342 h1:Q4vocNHLyy8V8jeSPoqidX5IpJbbcrQAyRrEXmIx68U=
 github.com/pion/webrtc/v3 v3.0.0-beta.4.0.20200902134452-789ff0975342/go.mod h1:0OXkpoNfLp1pgvyu4zF3zkkoyj82LQEJCqnG9wQEc7o=
+github.com/pion/webrtc/v3 v3.0.0-beta.4.0.20200908143909-40eb1f2404c0 h1:JXP3UYoTwnZ98cuvgI2ajEXh7G3TKfRKbGAvTWPZbT0=
 github.com/pion/webrtc/v3 v3.0.0-beta.4.0.20200908143909-40eb1f2404c0/go.mod h1:0OXkpoNfLp1pgvyu4zF3zkkoyj82LQEJCqnG9wQEc7o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
update causes

```
go: finding module for package google.golang.org/grpc/naming
/go/pkg/mod/google.golang.org/api@v0.13.0/internal/pool.go:10:2: module google.golang.org/grpc@latest found (v1.32.0), but does not contain package google.golang.org/grpc/naming
ERROR: Service 'avp' failed to build: The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /avp .' returned a non-zero code: 1
```