### PR TITLE
webm: Allow saving audio only.

### DIFF
--- a/examples/save-to-webm/server/main.go
+++ b/examples/save-to-webm/server/main.go
@@ -37,7 +37,7 @@ func createWebmSaver(sid, pid, tid string, config []byte) avp.Element {
 		path.Join(conf.Webmsaver.Path, fmt.Sprintf("%s-%s.webm", sid, pid)),
 		4096,
 	)
-	webm := elements.NewWebmSaver()
+	webm := elements.NewWebmSaver(nil)
 	webm.Attach(filewriter)
 	return webm
 }

--- a/pkg/elements/webm.go
+++ b/pkg/elements/webm.go
@@ -113,7 +113,7 @@ func (s *WebmSaver) pushVP8(sample *avp.Sample) {
 		width := int(raw & 0x3FFF)
 		height := int((raw >> 16) & 0x3FFF)
 
-		if s.videoWriter == nil || s.audioWriter == nil {
+		if s.videoWriter == nil {
 			// Initialize WebM saver using received frame size.
 			s.initWriter(width, height)
 		}

--- a/pkg/elements/webm.go
+++ b/pkg/elements/webm.go
@@ -158,9 +158,17 @@ func (s *WebmSaver) initWriter(width, height int) {
 		audioIdx = 0
 	}
 	if s.cfg.Video {
+		var trackNum uint64
+		if s.cfg.Audio {
+			trackNum = 2
+			videoIdx = 1
+		} else {
+			trackNum = 1
+			videoIdx = 0
+		}
 		tracks = append(tracks, webm.TrackEntry{
 			Name:            "Video",
-			TrackNumber:     2,
+			TrackNumber:     trackNum,
 			TrackUID:        67890,
 			CodecID:         "V_VP8",
 			TrackType:       1,
@@ -170,11 +178,6 @@ func (s *WebmSaver) initWriter(width, height int) {
 				PixelHeight: uint64(height),
 			},
 		})
-		if s.cfg.Audio {
-			videoIdx = 1
-		} else {
-			videoIdx = 0
-		}
 	}
 	ws, err := webm.NewSimpleBlockWriter(s.sampleWriter, tracks, options...)
 	if err != nil {

--- a/pkg/elements/webm_test.go
+++ b/pkg/elements/webm_test.go
@@ -44,7 +44,7 @@ var rawKeyframePkt = []byte{
 var rawOpusPkt = []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90}
 
 func TestWebMSaver_BlockWriterInit(t *testing.T) {
-	saver := NewWebmSaver()
+	saver := NewWebmSaver(nil)
 
 	writer := NewBufWriter()
 	saver.Attach(writer)
@@ -75,8 +75,7 @@ func TestWebMSaver_BlockWriterInit(t *testing.T) {
 }
 
 func TestWebMSave_AudioOnly(t *testing.T) {
-	saver := NewWebmSaver()
-	saver.SetAudioOnly()
+	saver := NewWebmSaver(&WebmSaverConfig{Audio: true, Video: false})
 
 	writer := NewBufWriter()
 	saver.Attach(writer)

--- a/pkg/elements/webm_test.go
+++ b/pkg/elements/webm_test.go
@@ -73,3 +73,20 @@ func TestWebMSaver_BlockWriterInit(t *testing.T) {
 
 	assert.Len(t, header.Segment.Tracks.TrackEntry, 2)
 }
+
+func TestWebMSave_AudioOnly(t *testing.T) {
+	saver := NewWebmSaver()
+	saver.SetAudioOnly()
+
+	writer := NewBufWriter()
+	saver.Attach(writer)
+
+	err := saver.Write(&avp.Sample{
+		Type:    avp.TypeOpus,
+		Payload: rawOpusPkt,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, saver.audioWriter)
+
+	saver.Close()
+}


### PR DESCRIPTION
Previously we waited for a video keyframe to initialize the writers. Now if `SetAudioOnly` is called, we initialize the `audioWriter` on first audio packet. This allows saving audio-only sessions.
